### PR TITLE
Updated alpine linux container base version. Fixes #3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.1
+FROM gliderlabs/alpine:3.2
 
 RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 RUN apk update


### PR DESCRIPTION
The problem stemmed from the fact that the Dockerfile add the `edge`
repository to apk (alpine's package manager). Edge tracks the latest
version of the os and we where still basing ourselves of the 3.1 base
image up till now.