### PR TITLE
Fix startup failure due to non existent /run folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,7 @@ COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
+RUN mkdir -p /run/postgresql && chown -R postgres /run/postgresql
+
 EXPOSE 5432
 CMD ["postgres"]


### PR DESCRIPTION
Fixing this problem upon startup 

'waiting for server to start....FATAL:  could not create lock file "/run/postgresql/.s.PGSQL.5432.lock": No such file or directory' 

https://gist.github.com/nuaimat/5ae61d49949ce5b82fe16c8692b0d545